### PR TITLE
[bindings] .NET AOT build/test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         NUGET_RID: "${{ matrix.env.NUGET_RID }}"
       shell: cmd
       run: |
-        pwsh Bindings/dotnet/nuget-test-aot.ps1
+        pwsh.exe Bindings/dotnet/nuget-test-aot.ps1
 
     - name: create NuGet package
       if: "success() && matrix.env.NUGET_PACK_DOTNET_LIB == '1'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,15 +149,6 @@ jobs:
       run: |
         pwsh Bindings/dotnet/nuget-test-aot.ps1
 
-    - name: test AOT build and interop (Windows)
-      if: "success() && matrix.env.NUGET_RID != '' && matrix.env.OS == 'windows'"
-      env:
-        NUGET_VERSION: "${{ env.NUGET_BASE_VERSION }}.${{ github.run_number }}"
-        NUGET_RID: "${{ matrix.env.NUGET_RID }}"
-      shell: cmd
-      run: |
-        "C:\Program Files\PowerShell\7\pwsh.exe" Bindings/dotnet/nuget-test-aot.ps1
-
     - name: create NuGet package
       if: "success() && matrix.env.NUGET_PACK_DOTNET_LIB == '1'"
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         NUGET_RID: "${{ matrix.env.NUGET_RID }}"
       shell: cmd
       run: |
-        pwsh.exe Bindings/dotnet/nuget-test-aot.ps1
+        "C:\Program Files\PowerShell\7\pwsh.exe" Bindings/dotnet/nuget-test-aot.ps1
 
     - name: create NuGet package
       if: "success() && matrix.env.NUGET_PACK_DOTNET_LIB == '1'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,11 +141,20 @@ jobs:
       run: |
         pwsh Bindings/dotnet/nuget-pack-native.ps1
 
-    - name: test AOT build and interop
-      if: "success() && matrix.env.NUGET_RID != ''"
+    - name: test AOT build and interop (non-Windows)
+      if: "success() && matrix.env.NUGET_RID != '' && matrix.env.OS != 'windows'"
       env:
         NUGET_VERSION: "${{ env.NUGET_BASE_VERSION }}.${{ github.run_number }}"
         NUGET_RID: "${{ matrix.env.NUGET_RID }}"
+      run: |
+        pwsh Bindings/dotnet/nuget-test-aot.ps1
+
+    - name: test AOT build and interop (Windows)
+      if: "success() && matrix.env.NUGET_RID != '' && matrix.env.OS == 'windows'"
+      env:
+        NUGET_VERSION: "${{ env.NUGET_BASE_VERSION }}.${{ github.run_number }}"
+        NUGET_RID: "${{ matrix.env.NUGET_RID }}"
+      shell: cmd
       run: |
         pwsh Bindings/dotnet/nuget-test-aot.ps1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,13 +141,13 @@ jobs:
       run: |
         pwsh Bindings/dotnet/nuget-pack-native.ps1
 
-    #- name: test AOT build and interop
-    #  if: "success() && matrix.env.NUGET_RID != ''"
-    #  env:
-    #    NUGET_VERSION: "${{ env.NUGET_BASE_VERSION }}.${{ github.run_number }}"
-    #    NUGET_RID: "${{ matrix.env.NUGET_RID }}"
-    #  run: |
-    #    pwsh Bindings/dotnet/nuget-test-aot.ps1
+    - name: test AOT build and interop
+      if: "success() && matrix.env.NUGET_RID != ''"
+      env:
+        NUGET_VERSION: "${{ env.NUGET_BASE_VERSION }}.${{ github.run_number }}"
+        NUGET_RID: "${{ matrix.env.NUGET_RID }}"
+      run: |
+        pwsh Bindings/dotnet/nuget-test-aot.ps1
 
     - name: create NuGet package
       if: "success() && matrix.env.NUGET_PACK_DOTNET_LIB == '1'"

--- a/Bindings/dotnet/nuget-pack-dotnet.ps1
+++ b/Bindings/dotnet/nuget-pack-dotnet.ps1
@@ -1,3 +1,4 @@
+#!/usr/bin/env pwsh
 #Requires -PSEdition Core -Version 7.4
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'

--- a/Bindings/dotnet/nuget-pack-native.ps1
+++ b/Bindings/dotnet/nuget-pack-native.ps1
@@ -1,3 +1,4 @@
+#!/usr/bin/env pwsh
 #Requires -PSEdition Core -Version 7.4
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'

--- a/Bindings/dotnet/nuget-test-aot.ps1
+++ b/Bindings/dotnet/nuget-test-aot.ps1
@@ -1,3 +1,4 @@
+#!/usr/bin/env pwsh
 #Requires -PSEdition Core -Version 7.4
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
Add .NET AOT build/test step to CI, for platforms other than Windows; passed on Linux and macOS.

Windows CI is unfortunately behaving quite silly right now, with issues like https://github.com/royalapplications/royalvnc/actions/runs/14489045460/job/40641034096#step:12:235

> 'where' is not recognized as an internal or external command, operable program or batch file.
> %USERPROFILE%\.nuget\packages\microsoft.dotnet.ilcompiler\9.0.4\build\Microsoft.NETCore.Native.Windows.targets(138,5): error : Platform linker not found

Hopefully a solution for that will become apparent at some point.