### PR TITLE
Update macOS build environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,8 @@ jobs:
     - name: setup environment (Apple)
       if: "success() && matrix.env.OS == 'apple'"
       run: |
-        sudo xcode-select --switch /Applications/Xcode_16.2.app
+        sudo xcode-select --switch /Applications/Xcode_26.1.app
+        swift --version
 
     - name: setup VC++ environment (Windows)
       if: "success() && matrix.env.OS == 'windows'"


### PR DESCRIPTION
Bump GH CI from `macos-14` to `macos-latest` (ref. https://github.com/actions/runner-images#available-images that's `macos-15` currently, hopefully soon to be `macos-26`)

Bump XCode build tools from 16.2 (Swift 6.0.3) to 26.1 (Swift 6.2.1)

After selecting build environment, run `swift --version` to log which compiler was used in CI.